### PR TITLE
fix for image volumes under selinux

### DIFF
--- a/pkg/containerd/opts/container.go
+++ b/pkg/containerd/opts/container.go
@@ -114,5 +114,5 @@ func copyExistingContents(source, destination string) error {
 	if len(dstList) != 0 {
 		return errors.Errorf("volume at %q is not initially empty", destination)
 	}
-	return fs.CopyDir(destination, source)
+	return fs.CopyDir(destination, source, fs.WithXAttrExclude("security.selinux"))
 }


### PR DESCRIPTION
Leverage patch to containerd/continuity allowing for exclusion of xattr
keys when copying directories.

- addresses rancher/rke2#690
- see k3s-io/containerd#10

Signed-off-by: Jacob Blain Christen <jacob@rancher.com>